### PR TITLE
Add image upload script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+.env

--- a/README.md
+++ b/README.md
@@ -9,6 +9,20 @@ yarn install
 yarn start
 
 
+# Image upload to CMS
+
+- Currently there is a content management system hosted at http://173.249.12.47:8080;
+
+- Before you start you will need to have an account there (talk to 0xAlice) and an API key which can be found at http://173.249.12.47:8080/restadmin/index
+
+- Create a `.env` file and add `COCKPIT_API_KEY=<your key>`
+
+- Make sure that your images are in a flat folder and then get its relative (UNIX) path
+
+- Run the script with  node ./bin/post-images.js /path/to/images
+
+- NodeJS will start uploading images in chucks of 20 and they should start appearing at http://173.249.12.47:8080/assetsmanager
+
 # pentacle-ui
 
 

--- a/bin/post-images.js
+++ b/bin/post-images.js
@@ -31,7 +31,7 @@ let progress = 0;
 const token = process.env.COCKPIT_API_KEY;
 
 if (!token) {
-  console.error('Please add your token to .env file from http://173.249.12.47:8080/restadmin/index');
+  console.error('Please add your token to .env file from https://b0910e2e8a31.ngrok.io/restadmin/index');
   process.exit(1);
 }
 const folderId= '60c4db7be789842acc20e201'; // Ghibli gifs!
@@ -82,7 +82,7 @@ const getUploadFn = (buffers) => {
   };
 
   return from(
-    fetch(`http://173.249.12.47:8080/api/cockpit/addAssets?token=${token}`, requestOptions)
+    fetch(`https://b0910e2e8a31.ngrok.io/api/cockpit/addAssets?token=${token}`, requestOptions)
       .then(response => response.text())
       .then(result => {
         progress += buffers.length;

--- a/bin/post-images.js
+++ b/bin/post-images.js
@@ -1,0 +1,118 @@
+require('dotenv').config();
+var FormData = require('form-data');
+const {
+  existsSync
+} = require('fs');
+const {
+  readdir,
+  readFile
+} = require('fs/promises');
+const { join } = require('path');
+const { from, forkJoin } = require('rxjs');
+const { map, switchMap, concatMap } = require('rxjs/operators');
+const {v4} = require('uuid');
+const fetch = require("node-fetch");
+
+// eslint-disable-next-line no-extend-native
+Object.defineProperty(Array.prototype, 'chunk_inefficient', {
+  value: function(chunkSize) {
+    var array = this;
+    return [].concat.apply([],
+      array.map(function(elem, i) {
+        return i % chunkSize ? [] : [array.slice(i, i + chunkSize)];
+      })
+    );
+  }
+});
+
+
+let amt;
+let progress = 0;
+const token = process.env.COCKPIT_API_KEY;
+
+if (!token) {
+  console.error('Please add your token to .env file from http://173.249.12.47:8080/restadmin/index');
+  process.exit(1);
+}
+const folderId= '60c4db7be789842acc20e201'; // Ghibli gifs!
+
+const [,,sourceUrl] = process.argv;
+
+
+if (!existsSync(sourceUrl)) {
+  console.error(`
+Error!
+  
+Could not find folder ${sourceUrl}`);
+  process.exit(1);
+}
+
+console.log(`
+--------------------------------------------
+--------------- Welcome --------------------
+--------------------------------------------
+
+
+API key: ${token}
+Folder ID: ${folderId}
+
+
+Beginning loading of images.
+`)
+
+
+
+const getFileFuffers = () => from(readdir(sourceUrl)).pipe(
+  map(files => files.filter(f => f.endsWith('.gif'))),
+  map((files) => files.map((file) => readFile(join(sourceUrl, file)))),
+  switchMap((files) => forkJoin(files)),
+);
+
+
+const getUploadFn = (buffers) => {
+  var formdata = new FormData();
+
+  buffers.forEach(buffer => formdata.append('files[]', buffer, `${v4()}.gif`))
+  formdata.append("meta[folder]", folderId)
+
+  var requestOptions = {
+    method: 'POST',
+    body: formdata,
+    redirect: 'follow'
+  };
+
+  return from(
+    fetch(`http://173.249.12.47:8080/api/cockpit/addAssets?token=${token}`, requestOptions)
+      .then(response => response.text())
+      .then(result => {
+        progress += buffers.length;
+        console.log(`${progress}/${amt} uploaded!`)
+      })
+      .catch(error => console.log('error', error))
+  )
+}
+
+
+
+getFileFuffers().pipe(
+  switchMap((buffers) => {
+    const chunked = buffers.chunk_inefficient(20);
+    amt = buffers.length;
+
+    console.log(`
+--------------------------------------------
+----------- Upload starting ----------------
+--------------------------------------------
+
+
+Beginning upload of ${amt} images.
+    
+    
+    `);
+
+
+    return from(chunked).pipe(
+      concatMap((chunk) => getUploadFn(chunk))
+    )
+  })
+).subscribe()

--- a/package.json
+++ b/package.json
@@ -43,6 +43,11 @@
     ]
   },
   "devDependencies": {
-    "@babel/plugin-syntax-import-meta": "^7.10.4"
+    "@babel/plugin-syntax-import-meta": "^7.10.4",
+    "dotenv": "^10.0.0",
+    "form-data": "^4.0.0",
+    "node-fetch": "^2.6.1",
+    "rxjs": "^7.1.0",
+    "uuid": "^8.3.2"
   }
 }

--- a/sample.env
+++ b/sample.env
@@ -1,0 +1,1 @@
+COCKPIT_API_KEY=

--- a/yarn.lock
+++ b/yarn.lock
@@ -3442,7 +3442,7 @@ colorette@^1.2.2:
   resolved "https://registry.yarnpkg.com/colorette/-/colorette-1.2.2.tgz#cbcc79d5e99caea2dbf10eb3a26fd8b3e6acfa94"
   integrity sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w==
 
-combined-stream@^1.0.6, combined-stream@~1.0.6:
+combined-stream@^1.0.6, combined-stream@^1.0.8, combined-stream@~1.0.6:
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
   integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
@@ -4566,6 +4566,11 @@ dotenv@8.2.0:
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-8.2.0.tgz#97e619259ada750eea3e4ea3e26bceea5424b16a"
   integrity sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw==
 
+dotenv@^10.0.0:
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-10.0.0.tgz#3d4227b8fb95f81096cdd2b66653fb2c7085ba81"
+  integrity sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==
+
 duplexer@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/duplexer/-/duplexer-0.1.1.tgz#ace6ff808c1ce66b57d1ebf97977acb02334cfc1"
@@ -5464,6 +5469,15 @@ fork-ts-checker-webpack-plugin@4.1.6:
     semver "^5.6.0"
     tapable "^1.0.0"
     worker-rpc "^0.1.0"
+
+form-data@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.0.tgz#93919daeaf361ee529584b9b31664dc12c9fa452"
+  integrity sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    mime-types "^2.1.12"
 
 form-data@~2.3.2:
   version "2.3.3"
@@ -8013,6 +8027,11 @@ no-case@^3.0.4:
     lower-case "^2.0.2"
     tslib "^2.0.3"
 
+node-fetch@^2.6.1:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
+  integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
+
 node-forge@^0.10.0:
   version "0.10.0"
   resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-0.10.0.tgz#32dea2afb3e9926f02ee5ce8794902691a676bf3"
@@ -10449,6 +10468,13 @@ rxjs@^6.5.3, rxjs@^6.6.0:
   dependencies:
     tslib "^1.9.0"
 
+rxjs@^7.1.0:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-7.1.0.tgz#94202d27b19305ef7b1a4f330277b2065df7039e"
+  integrity sha512-gCFO5iHIbRPwznl6hAYuwNFld8W4S2shtSJIqG27ReWXo9IWrCyEICxUA+6vJHwSR/OakoenC4QsDxq50tzYmw==
+  dependencies:
+    tslib "~2.1.0"
+
 safe-buffer@5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
@@ -11507,6 +11533,11 @@ tslib@^2.0.3:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.2.0.tgz#fb2c475977e35e241311ede2693cee1ec6698f5c"
   integrity sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==
 
+tslib@~2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.1.0.tgz#da60860f1c2ecaa5703ab7d39bc05b6bf988b97a"
+  integrity sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==
+
 tsutils@^3.17.1:
   version "3.17.1"
   resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-3.17.1.tgz#ed719917f11ca0dee586272b2ac49e015a2dd759"
@@ -11770,6 +11801,11 @@ uuid@^3.3.2:
   version "3.3.3"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.3.tgz#4568f0216e78760ee1dbf3a4d2cf53e224112866"
   integrity sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ==
+
+uuid@^8.3.2:
+  version "8.3.2"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
+  integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
 
 v8-compile-cache@^2.0.3:
   version "2.1.0"


### PR DESCRIPTION
# Changes

- added some devDeps to make life easier
- added .gitignore
- add bin/post-images.js

# How-to
- `npm i` or `yarn`

- Currently there is a content management system hosted at http://173.249.12.47:8080;

- Before you start you will need to have an account there (talk to 0xAlice) and an API key which can be found at http://173.249.12.47:8080/restadmin/index

- Create a `.env` file and add `COCKPIT_API_KEY=<your key>`

- Make sure that your images are in a flat folder and then get its relative (UNIX) path

- Run the script with  node ./bin/post-images.js /path/to/images

- NodeJS will start uploading images in chucks of 20 and they should start appearing at http://173.249.12.47:8080/assetsmanager