### PR TITLE
Feature/lazy images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+.env

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ yarn start
 
 - Before you start you will need to have an account there (talk to 0xAlice) and an API key which can be found at http://173.249.12.47:8080/restadmin/index
 
-- Create a `.env` file and add `COCKPIT_API_KEY=<your key>`
+- Create a `.env` file and add `REACT_APP_COCKPIT_API_KEY=<your key>`
 
 - Make sure that your images are in a flat folder and then get its relative (UNIX) path
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,20 @@ yarn install
 yarn start
 
 
+# Image upload to CMS
+
+- Currently there is a content management system hosted at http://173.249.12.47:8080;
+
+- Before you start you will need to have an account there (talk to 0xAlice) and an API key which can be found at http://173.249.12.47:8080/restadmin/index
+
+- Create a `.env` file and add `COCKPIT_API_KEY=<your key>`
+
+- Make sure that your images are in a flat folder and then get its relative (UNIX) path
+
+- Run the script with  node ./bin/post-images.js /path/to/images
+
+- NodeJS will start uploading images in chucks of 20 and they should start appearing at http://173.249.12.47:8080/assetsmanager
+
 # pentacle-ui
 
 

--- a/bin/post-images.js
+++ b/bin/post-images.js
@@ -28,7 +28,7 @@ Object.defineProperty(Array.prototype, 'chunk_inefficient', {
 
 let amt;
 let progress = 0;
-const token = process.env.COCKPIT_API_KEY;
+const token = process.env.REACT_APP_COCKPIT_API_KEY;
 
 if (!token) {
   console.error('Please add your token to .env file from https://b0910e2e8a31.ngrok.io/restadmin/index');

--- a/bin/post-images.js
+++ b/bin/post-images.js
@@ -31,7 +31,7 @@ let progress = 0;
 const token = process.env.COCKPIT_API_KEY;
 
 if (!token) {
-  console.error('Please add your token to .env file from http://173.249.12.47:8080/restadmin/index');
+  console.error('Please add your token to .env file from https://b0910e2e8a31.ngrok.io/restadmin/index');
   process.exit(1);
 }
 const folderId= '60c4db7be789842acc20e201'; // Ghibli gifs!
@@ -82,7 +82,7 @@ const getUploadFn = (buffers) => {
   };
 
   return from(
-    fetch(`http://173.249.12.47:8080/api/cockpit/addAssets?token=${token}`, requestOptions)
+    fetch(`https://b0910e2e8a31.ngrok.io/api/cockpit/addAssets?token=${token}`, requestOptions)
       .then(response => response.text())
       .then(result => {
         progress += buffers.length;

--- a/bin/post-images.js
+++ b/bin/post-images.js
@@ -1,0 +1,118 @@
+require('dotenv').config();
+var FormData = require('form-data');
+const {
+  existsSync
+} = require('fs');
+const {
+  readdir,
+  readFile
+} = require('fs/promises');
+const { join } = require('path');
+const { from, forkJoin } = require('rxjs');
+const { map, switchMap, concatMap } = require('rxjs/operators');
+const {v4} = require('uuid');
+const fetch = require("node-fetch");
+
+// eslint-disable-next-line no-extend-native
+Object.defineProperty(Array.prototype, 'chunk_inefficient', {
+  value: function(chunkSize) {
+    var array = this;
+    return [].concat.apply([],
+      array.map(function(elem, i) {
+        return i % chunkSize ? [] : [array.slice(i, i + chunkSize)];
+      })
+    );
+  }
+});
+
+
+let amt;
+let progress = 0;
+const token = process.env.COCKPIT_API_KEY;
+
+if (!token) {
+  console.error('Please add your token to .env file from http://173.249.12.47:8080/restadmin/index');
+  process.exit(1);
+}
+const folderId= '60c4db7be789842acc20e201'; // Ghibli gifs!
+
+const [,,sourceUrl] = process.argv;
+
+
+if (!existsSync(sourceUrl)) {
+  console.error(`
+Error!
+  
+Could not find folder ${sourceUrl}`);
+  process.exit(1);
+}
+
+console.log(`
+--------------------------------------------
+--------------- Welcome --------------------
+--------------------------------------------
+
+
+API key: ${token}
+Folder ID: ${folderId}
+
+
+Beginning loading of images.
+`)
+
+
+
+const getFileFuffers = () => from(readdir(sourceUrl)).pipe(
+  map(files => files.filter(f => f.endsWith('.gif'))),
+  map((files) => files.map((file) => readFile(join(sourceUrl, file)))),
+  switchMap((files) => forkJoin(files)),
+);
+
+
+const getUploadFn = (buffers) => {
+  var formdata = new FormData();
+
+  buffers.forEach(buffer => formdata.append('files[]', buffer, `${v4()}.gif`))
+  formdata.append("meta[folder]", folderId)
+
+  var requestOptions = {
+    method: 'POST',
+    body: formdata,
+    redirect: 'follow'
+  };
+
+  return from(
+    fetch(`http://173.249.12.47:8080/api/cockpit/addAssets?token=${token}`, requestOptions)
+      .then(response => response.text())
+      .then(result => {
+        progress += buffers.length;
+        console.log(`${progress}/${amt} uploaded!`)
+      })
+      .catch(error => console.log('error', error))
+  )
+}
+
+
+
+getFileFuffers().pipe(
+  switchMap((buffers) => {
+    const chunked = buffers.chunk_inefficient(20);
+    amt = buffers.length;
+
+    console.log(`
+--------------------------------------------
+----------- Upload starting ----------------
+--------------------------------------------
+
+
+Beginning upload of ${amt} images.
+    
+    
+    `);
+
+
+    return from(chunked).pipe(
+      concatMap((chunk) => getUploadFn(chunk))
+    )
+  })
+).subscribe()

--- a/package.json
+++ b/package.json
@@ -43,6 +43,11 @@
     ]
   },
   "devDependencies": {
-    "@babel/plugin-syntax-import-meta": "^7.10.4"
+    "@babel/plugin-syntax-import-meta": "^7.10.4",
+    "dotenv": "^10.0.0",
+    "form-data": "^4.0.0",
+    "node-fetch": "^2.6.1",
+    "rxjs": "^7.1.0",
+    "uuid": "^8.3.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "homepage": ".",
   "dependencies": {
     "@observablehq/runtime": "^4.8.2",
+    "@react-hook/intersection-observer": "^3.1.1",
     "@testing-library/jest-dom": "^4.2.4",
     "@testing-library/react": "^9.3.2",
     "@testing-library/user-event": "^7.1.2",

--- a/sample.env
+++ b/sample.env
@@ -1,0 +1,1 @@
+COCKPIT_API_KEY=

--- a/src/pages/main.js
+++ b/src/pages/main.js
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 import Layout from '../components/layout';
 import useIntersectionObserver from '@react-hook/intersection-observer';
 
-const baseUrl = 'http://173.249.12.47:8080';
+const baseUrl = 'https://b0910e2e8a31.ngrok.io';
 const Img = ({ path, thumb }) => {
   const [ref, setRef] = useState();
   const { isIntersecting } = useIntersectionObserver(ref);

--- a/src/pages/main.js
+++ b/src/pages/main.js
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import Layout from '../components/layout';
 import useIntersectionObserver from '@react-hook/intersection-observer';
+require('dotenv').config();
 
 const baseUrl = 'https://b0910e2e8a31.ngrok.io';
 const Img = ({ path, thumb }) => {
@@ -21,10 +22,11 @@ const Img = ({ path, thumb }) => {
 
 export const Main = () => {
   const [images, setImages] = useState([]);
+  const token = process.env.REACT_APP_COCKPIT_API_KEY;
 
   useEffect(() => {
     fetch(
-      `${baseUrl}/api/cockpit/assets?token=7cd55d17658deb489b779ef537a864`,
+      `${baseUrl}/api/cockpit/assets?token=${token}`,
       {
         method: 'post',
         headers: { 'Content-Type': 'application/json' },
@@ -40,7 +42,7 @@ export const Main = () => {
             .map(({ path, _id }) => ({ path, _id }))
             .map(async ({ path, _id }) => {
               const params = new URLSearchParams();
-              params.append('token', '7cd55d17658deb489b779ef537a864');
+              params.append('token', token);
               params.append('src', _id);
               params.append('w', '200');
               params.append('m', 'bestFit');
@@ -58,7 +60,7 @@ export const Main = () => {
 
         setImages(img);
       });
-  }, []);
+  }, [token]);
 
   return (
     <Layout>

--- a/src/pages/main.js
+++ b/src/pages/main.js
@@ -1,97 +1,72 @@
-import React from "react";
-import Layout from "../components/layout";
+import React, { useEffect, useState } from 'react';
+import Layout from '../components/layout';
+import useIntersectionObserver from '@react-hook/intersection-observer';
 
-
-import arietty from "../assets/images/gifs/arietty.gif";
-import butterfly from "../assets/images/gifs/butterfly.gif";
-import cat from "../assets/images/gifs/cat-gif.gif";
-import dragon from "../assets/images/gifs/dragon.gif";
-import ephemeris from "../assets/images/gifs/ephemeris.gif";
-import farming from "../assets/images/gifs/farming.gif";
-import forestspirit from "../assets/images/gifs/forest-spirit.gif";
-import lake from "../assets/images/gifs/ghibli-lake-flower.gif";
-import heart from "../assets/images/gifs/heart-swallow.gif";
-import howl from "../assets/images/gifs/howl.gif";
-import howlasleep from "../assets/images/gifs/howl-asleep.gif";
-import howllook from "../assets/images/gifs/howl-look.gif";
-import kaguya from "../assets/images/gifs/kaguya.gif";
-import kaguya02 from "../assets/images/gifs/kaguya-2.gif";
-import kaguya03 from "../assets/images/gifs/kaguya-3.gif";
-import kaguyafarm from "../assets/images/gifs/kaguya-farm.gif";
-import kiki01 from "../assets/images/gifs/kiki-boy.gif";
-import kiki02 from "../assets/images/gifs/kiki-waves.gif";
-import kiki03 from "../assets/images/gifs/kiki-window.gif";
-import mononoke01 from "../assets/images/gifs/mononoke-butterflies.gif";
-import mononoke02 from "../assets/images/gifs/mononoke-spirits.gif";
-import mononoke03 from "../assets/images/gifs/run-mononoke.gif";
-import nausicaa from "../assets/images/gifs/nausicaa-and-her-pet.gif";
-import ponyo01 from "../assets/images/gifs/ponyo-hug-1.gif";
-import ponyo02 from "../assets/images/gifs/ponyo-hug.gif";
-import ponyo03 from "../assets/images/gifs/ponyo-kiss.gif";
-import ponyo04 from "../assets/images/gifs/ponyo-moon.gif";
-import ponyo05 from "../assets/images/gifs/ponyo-mum.gif";
-import ponyo06 from "../assets/images/gifs/ponyo-running-3.gif";
-import ponyo07 from "../assets/images/gifs/ponyo-wake-up.gif";
-import ponyo08 from "../assets/images/gifs/ponyo.gif";
-import poppyHill from "../assets/images/gifs/poppy-hill-rain.gif";
-import rainbow from "../assets/images/gifs/rainbow-rowing.gif";
-import runMononoke from "../assets/images/gifs/run-mononoke.gif";
-import smoking from "../assets/images/gifs/smoking.gif";
-import sophieNight from "../assets/images/gifs/sophie-night.gif";
-import sophieRun from "../assets/images/gifs/sophie-run.gif";
-import sosuke02 from "../assets/images/gifs/sosuke-02.gif";
-import totoroPls from "../assets/images/gifs/totoro-pls.gif";
-import totoroRain from "../assets/images/gifs/totoro-rain.gif";
-import waterReflection from "../assets/images/gifs/water-reflection.gif";
-
+const baseUrl = 'http://173.249.12.47:8080';
+const Img = ({ path, thumb }) => {
+  const [ref, setRef] = useState();
+  const { isIntersecting } = useIntersectionObserver(ref);
+  return (
+    <>
+      <img
+        key={path}
+        ref={setRef}
+        src={isIntersecting ? path : thumb}
+        alt="Studio Ghibli Animation"
+        loading="lazy"
+      />
+    </>
+  );
+};
 
 export const Main = () => {
-    return (
-        <Layout>
-            <section>
-                <img src={arietty} alt="studio ghibli"/>
-                <img src={butterfly} alt="studio ghibli"/>
-                <img src={cat} alt="studio ghibli"/>
-                <img src={dragon} alt="studio ghibli"/>
-                <img src={ephemeris} alt="studio ghibli"/>
-                <img src={farming} alt="studio ghibli"/>
-                <img src={forestspirit} alt="studio ghibli"/>
-                <img src={lake} alt="studio ghibli"/>
-                <img src={heart} alt="studio ghibli"/>
-                <img src={howl} alt="studio ghibli"/>
-                <img src={howlasleep} alt="studio ghibli"/>
-                <img src={howllook} alt="studio ghibli"/>
-                <img src={kaguya} alt="studio ghibli"/>
-                <img src={kaguya02} alt="studio ghibli"/>
-                <img src={kaguya03} alt="studio ghibli"/>
-                <img src={kaguyafarm} alt="studio ghibli"/>
+  const [images, setImages] = useState([]);
 
-                <img src={kiki01} alt="studio ghibli"/>
-                <img src={kiki02} alt="studio ghibli"/>
-                <img src={kiki03} alt="studio ghibli"/>
-                <img src={mononoke01} alt="studio ghibli"/>
-                <img src={mononoke02} alt="studio ghibli"/>
-                <img src={mononoke03} alt="studio ghibli"/>
-                <img src={nausicaa} alt="studio ghibli"/>
-                <img src={ponyo01} alt="studio ghibli"/>
-                <img src={ponyo02} alt="studio ghibli"/>
-                <img src={ponyo03} alt="studio ghibli"/>
-                <img src={ponyo04} alt="studio ghibli"/>
-                <img src={ponyo05} alt="studio ghibli"/>
-                <img src={ponyo06} alt="studio ghibli"/>
-                <img src={ponyo07} alt="studio ghibli"/>
-                <img src={ponyo08} alt="studio ghibli"/>
-                <img src={poppyHill} alt="studio ghibli"/>
-                <img src={rainbow} alt="studio ghibli"/>
-                <img src={smoking} alt="studio ghibli"/>
-                <img src={runMononoke} alt="studio ghibli"/>
-                <img src={sophieNight} alt="studio ghibli"/>
-                <img src={sophieRun} alt="studio ghibli"/>
-                <img src={totoroPls} alt="studio ghibli"/>
-                <img src={totoroRain} alt="studio ghibli"/>
-                <img src={waterReflection} alt="studio ghibli"/>
-                <img src={sosuke02} alt="studio ghibli"/>
-            </section>
-        </Layout>
+  useEffect(() => {
+    fetch(
+      `${baseUrl}/api/cockpit/assets?token=7cd55d17658deb489b779ef537a864`,
+      {
+        method: 'post',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          filter: { folder: '60c4db7be789842acc20e201' },
+        }),
+      }
     )
-}
+      .then((assets) => assets.json())
+      .then(async (assets) => {
+        const img = await Promise.all(
+          assets.assets
+            .map(({ path, _id }) => ({ path, _id }))
+            .map(async ({ path, _id }) => {
+              const params = new URLSearchParams();
+              params.append('token', '7cd55d17658deb489b779ef537a864');
+              params.append('src', _id);
+              params.append('w', '200');
+              params.append('m', 'bestFit');
+
+              return await fetch(
+                `${baseUrl}/api/cockpit/image?${params.toString()}`
+              )
+                .then((res) => res.text())
+                .then((res) => ({
+                  path: `${baseUrl}/storage/uploads${path}`,
+                  thumb: res,
+                }));
+            })
+        );
+
+        setImages(img);
+      });
+  }, []);
+
+  return (
+    <Layout>
+      <section>
+        {images.map(({ path, thumb }) => (
+          <Img path={path} thumb={thumb} />
+        ))}
+      </section>
+    </Layout>
+  );
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -1605,6 +1605,19 @@
   dependencies:
     d3-require "^1.2.4"
 
+"@react-hook/intersection-observer@^3.1.1":
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/@react-hook/intersection-observer/-/intersection-observer-3.1.1.tgz#6b8fdb80d133c9c28bc8318368ecb3a1f8befc50"
+  integrity sha512-OTDx8/wFaRvzFtKl1dEUEXSOqK2zVJHporiTTdC2xO++0e9FEx9wIrPis5q3lqtXeZH9zYGLbk+aB75qNFbbuw==
+  dependencies:
+    "@react-hook/passive-layout-effect" "^1.2.0"
+    intersection-observer "^0.10.0"
+
+"@react-hook/passive-layout-effect@^1.2.0":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@react-hook/passive-layout-effect/-/passive-layout-effect-1.2.1.tgz#c06dac2d011f36d61259aa1c6df4f0d5e28bc55e"
+  integrity sha512-IwEphTD75liO8g+6taS+4oqz+nnroocNfWVHWz7j+N+ZO2vYrc6PV1q7GQhuahL0IOR7JccFTsFKQ/mb6iZWAg==
+
 "@sheerun/mutationobserver-shim@^0.3.2":
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/@sheerun/mutationobserver-shim/-/mutationobserver-shim-0.3.3.tgz#5405ee8e444ed212db44e79351f0c70a582aae25"
@@ -6300,6 +6313,11 @@ internmap@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/internmap/-/internmap-1.0.1.tgz#0017cc8a3b99605f0302f2b198d272e015e5df95"
   integrity sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==
+
+intersection-observer@^0.10.0:
+  version "0.10.0"
+  resolved "https://registry.yarnpkg.com/intersection-observer/-/intersection-observer-0.10.0.tgz#4d11d63c1ff67e21e62987be24d55218da1a1a69"
+  integrity sha512-fn4bQ0Xq8FTej09YC/jqKZwtijpvARlRp6wxL5WTA6yPe2YWSJ5RJh7Nm79rK2qB0wr6iDQzH60XGq5V/7u8YQ==
 
 invariant@^2.2.2, invariant@^2.2.4:
   version "2.2.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3442,7 +3442,7 @@ colorette@^1.2.2:
   resolved "https://registry.yarnpkg.com/colorette/-/colorette-1.2.2.tgz#cbcc79d5e99caea2dbf10eb3a26fd8b3e6acfa94"
   integrity sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w==
 
-combined-stream@^1.0.6, combined-stream@~1.0.6:
+combined-stream@^1.0.6, combined-stream@^1.0.8, combined-stream@~1.0.6:
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
   integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
@@ -4566,6 +4566,11 @@ dotenv@8.2.0:
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-8.2.0.tgz#97e619259ada750eea3e4ea3e26bceea5424b16a"
   integrity sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw==
 
+dotenv@^10.0.0:
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-10.0.0.tgz#3d4227b8fb95f81096cdd2b66653fb2c7085ba81"
+  integrity sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==
+
 duplexer@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/duplexer/-/duplexer-0.1.1.tgz#ace6ff808c1ce66b57d1ebf97977acb02334cfc1"
@@ -5464,6 +5469,15 @@ fork-ts-checker-webpack-plugin@4.1.6:
     semver "^5.6.0"
     tapable "^1.0.0"
     worker-rpc "^0.1.0"
+
+form-data@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.0.tgz#93919daeaf361ee529584b9b31664dc12c9fa452"
+  integrity sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    mime-types "^2.1.12"
 
 form-data@~2.3.2:
   version "2.3.3"
@@ -8013,6 +8027,11 @@ no-case@^3.0.4:
     lower-case "^2.0.2"
     tslib "^2.0.3"
 
+node-fetch@^2.6.1:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
+  integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
+
 node-forge@^0.10.0:
   version "0.10.0"
   resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-0.10.0.tgz#32dea2afb3e9926f02ee5ce8794902691a676bf3"
@@ -10449,6 +10468,13 @@ rxjs@^6.5.3, rxjs@^6.6.0:
   dependencies:
     tslib "^1.9.0"
 
+rxjs@^7.1.0:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-7.1.0.tgz#94202d27b19305ef7b1a4f330277b2065df7039e"
+  integrity sha512-gCFO5iHIbRPwznl6hAYuwNFld8W4S2shtSJIqG27ReWXo9IWrCyEICxUA+6vJHwSR/OakoenC4QsDxq50tzYmw==
+  dependencies:
+    tslib "~2.1.0"
+
 safe-buffer@5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
@@ -11507,6 +11533,11 @@ tslib@^2.0.3:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.2.0.tgz#fb2c475977e35e241311ede2693cee1ec6698f5c"
   integrity sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==
 
+tslib@~2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.1.0.tgz#da60860f1c2ecaa5703ab7d39bc05b6bf988b97a"
+  integrity sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==
+
 tsutils@^3.17.1:
   version "3.17.1"
   resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-3.17.1.tgz#ed719917f11ca0dee586272b2ac49e015a2dd759"
@@ -11770,6 +11801,11 @@ uuid@^3.3.2:
   version "3.3.3"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.3.tgz#4568f0216e78760ee1dbf3a4d2cf53e224112866"
   integrity sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ==
+
+uuid@^8.3.2:
+  version "8.3.2"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
+  integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
 
 v8-compile-cache@^2.0.3:
   version "2.1.0"


### PR DESCRIPTION
This PR contains changes from the previous PR because they kinda belong to each other and this code is tied to the location where we upload the images, so I decided to stack them.

- adds image-upload script
- adds dev-dependencies for image-upload script 
  - dotenv, form-data, node-fetch, rxjs, uuid
  - all of which are very well-known and maintained projects
- adds a dependency which consists literally of one js file, if we want to not be tied to the dep we can pull the code right in
  - https://github.com/jaredLunde/react-hook/tree/master/packages/intersection-observer#readme
- loads images from CMS at https://b0910e2e8a31.ngrok.io
  - initially loads thumbnails and when images scrolls into view, thumbnail is replaced by actual gif